### PR TITLE
Made update-rust-nightly more resilient.

### DIFF
--- a/bin/update-rust-nightly
+++ b/bin/update-rust-nightly
@@ -1,16 +1,18 @@
 #!/bin/bash
 set -e
 
-RUST_URL=https://static.rust-lang.org/dist/rust-nightly-x86_64-apple-darwin.tar.gz
+rust_url="https://static.rust-lang.org/dist/rust-nightly-x86_64-apple-darwin.tar.gz"
 
-DIR=`brew --cellar`/rust/HEAD
+install_dir="$(brew --cellar)/rust/HEAD"
+new_dir="${install_dir}.new"
+old_dir="${install_dir}.old"
 
-rm -rf ${DIR}.new
-mkdir -p ${DIR}.new
-curl ${RUST_URL} |tar -C ${DIR}.new --strip-components 1 -zxf -
+[[ -d "$new_dir" ]] && rm -rf "$new_dir"
+mkdir -p "$new_dir"
+curl "$rust_url" | tar -C "$new_dir" --strip-components 1 -zxf -
 
-brew unlink rust || true
-rm -rf ${DIR}.old
-mv ${DIR} ${DIR}.old
-mv ${DIR}.new ${DIR}
+brew unlink rust
+[[ -d "$old_dir" ]] && rm -rf "$old_dir"
+[[ -d "$install_dir" ]] && mv "$install_dir" "$old_dir"
+mv "$new_dir" "$install_dir"
 brew link rust


### PR DESCRIPTION
- Same as https://github.com/cowboy/dotfiles/blob/209974c/bin/update-rust-nightly
- Paths are quoted, in case brew cellar root contains spaces.
- Dirs are only deleted or moved if they exist, allowing the script to actually run the first time.
